### PR TITLE
os x compatibility

### DIFF
--- a/systems/native-posix/system.c
+++ b/systems/native-posix/system.c
@@ -1,7 +1,9 @@
 #include "freertps/freertps.h"
 #include "freertps/system.h"
 #include <stdlib.h>
+#if defined(__linux__)
 #include <malloc.h>
+#endif
 #include <execinfo.h>
 #include "freertps/psm.h"
 

--- a/systems/native-posix/time.c
+++ b/systems/native-posix/time.c
@@ -1,16 +1,41 @@
 #include "freertps/time.h"
+
+#if defined(__linux__)
 #include <time.h>
+#else
+#include <sys/time.h>
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+static uint64_t frac_sec(uint64_t nsec)
+{
+  // convert nanoseconds to the RTPS fractional seconds
+  // FUTURE: provide faster macros for this which lose precision
+  const uint64_t frac_sec_lcm = nsec * 8388608;
+  return frac_sec_lcm / 1953125;
+}
 
 fr_time_t fr_time_now()
 {
+  fr_time_t now;
+
+#if (defined __linux__)
   struct timespec ts;
   clock_gettime(CLOCK_REALTIME, &ts);
-  // convert nanoseconds to the RTPS fractional seconds
-  // FUTURE: provide faster macros for this which lose precision
-  const uint64_t frac_sec_lcm = (uint64_t)ts.tv_nsec * 8388608;
-  const uint64_t frac_sec = frac_sec_lcm / 1953125;
-  fr_time_t now;
   now.seconds = ts.tv_sec;
-  now.fraction = frac_sec;
+  now.fraction = frac_sec(ts.tv_nsec);
+#else
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+
+  now.seconds = mts.tv_sec;
+  now.fraction = frac_sec(mts.tv_nsec);
+#endif
+
   return now;
 }


### PR DESCRIPTION
few patches to run on OS X - happy to edit these as needed.

also, a couple other items are required, but i wasn't sure how you'd prefer to resolve:
* clang doesn't accept `--start-group` and `--end-group` in CMakeLists.txt - would it make sense to categorize the non-native builds separately and only apply this to them?
* `lightweightserial` relies on `#include <linux/serial.h>` - is it possible to implement only in terms of termios and friends?

thoughts?