### PR TITLE
Consolidate union and struct in rtps_active_psms

### DIFF
--- a/include/freertps/freertps.h
+++ b/include/freertps/freertps.h
@@ -27,20 +27,17 @@ typedef void (*freertps_msg_cb_t)(const void *msg);
 #define FREERTPS_FATAL(...) \
   do { printf("freertps FATAL: "); printf(__VA_ARGS__); } while (0)
 
-typedef struct rtps_active_psms
+typedef union rtps_active_psms
 {
-  union
-  {
     uint32_t val;
     struct rtps_active_psms_mask
     {
       uint32_t udp : 1;
       uint32_t ser : 1;
     } s;
-  };
 } __attribute__((packed)) rtps_active_psms_t;
 
-extern struct rtps_active_psms g_rtps_active_psms;
+extern union rtps_active_psms g_rtps_active_psms;
 
 void freertps_create_sub(const char *topic_name,
                          const char *type_name,


### PR DESCRIPTION
I got a compile error when working on getting `rmw_freertps` to compile where an anonymous union was not allowed inside of a struct. Rather than give the union a name I decided to declare `rtps_active_psms` as a union, since the union was the only thing in this struct. I think this is okay, please let me know if it breaks everything.