### PR TITLE
Export system library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,7 @@ target_link_libraries(freertps freertps_system_${SYSTEM})
 include_directories(build/msgs)
 
 if (NOT freertps_standalone)
-  ament_export_libraries(freertps)
-  #ament_export_libraries(freertps_system_${SYSTEM})
+  ament_export_libraries(freertps freertps_system_${SYSTEM})
   ament_package()
   install(
     DIRECTORY include/


### PR DESCRIPTION
I had a problem linking ROS 2 code against freertps (undefined references to several functions in rmw_freertps). This fixed the linking problem, although a better fix may exist.