### PR TITLE
add gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,6 @@ if (NOT freertps_standalone)
     find_package(ament_cmake_gtest REQUIRED)
 
     ament_add_gtest(talker_listener_gtest "tests/talker_listener_test.cpp" TIMEOUT 30)
-    set_target_properties(talker_listener_gtest PROPERTIES LINKER_LANGUAGE CXX)
     if (TARGET talker_listener_gtest)
       ament_target_dependencies(talker_listener_gtest "freertps")
       target_include_directories(talker_listener_gtest PUBLIC include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,6 @@ if (NOT freertps_standalone)
     endif()
   endif()
 
-  #add_executable(standalone_talk_n apps/standalone_talk_n/standalone_talk_n.c)
-
   ament_package()
   install(
     DIRECTORY include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ function(freertps_add_executable exe)
   endif()
 endfunction()
 
-set(SYSTEM "native-posix" CACHE STRING "the target system name") 
+set(SYSTEM "native-posix" CACHE STRING "the target system name")
 message("system: [${SYSTEM}]")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -g -O2 -fPIC")
@@ -71,12 +71,26 @@ include_directories(build/msgs)
 
 if (NOT freertps_standalone)
   ament_export_libraries(freertps freertps_system_${SYSTEM})
+
+  if (AMENT_ENABLE_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+
+    ament_add_gtest(talker_listener_gtest "tests/talker_listener_test.cpp" TIMEOUT 30)
+    set_target_properties(talker_listener_gtest PROPERTIES LINKER_LANGUAGE CXX)
+    if (TARGET talker_listener_gtest)
+      ament_target_dependencies(talker_listener_gtest "freertps")
+      target_include_directories(talker_listener_gtest PUBLIC include)
+      target_link_libraries(talker_listener_gtest ${_AMENT_EXPORT_LIBRARY_TARGETS} ${SYSTEM_EXTRA_LIBS} ${SYSTEM_BONUS_LIBS})
+    endif()
+  endif()
+
+  #add_executable(standalone_talk_n apps/standalone_talk_n/standalone_talk_n.c)
+
   ament_package()
   install(
     DIRECTORY include/
     DESTINATION include
   )
-    #TARGETS freertps systems/freertps_system_${SYSTEM}
   install(
     TARGETS freertps
     ARCHIVE DESTINATION lib

--- a/include/freertps/freertps.h
+++ b/include/freertps/freertps.h
@@ -1,6 +1,10 @@
 #ifndef FREERTPS_H
 #define FREERTPS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdio.h>
 
 // NOTE: the prefix freertps_udp_ is too long to type, so it will often
@@ -56,5 +60,9 @@ bool freertps_publish(frudp_pub_t *pub,
 extern bool g_freertps_init_complete;
 
 void freertps_start();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/package.xml
+++ b/package.xml
@@ -8,9 +8,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tests/talker_listener_test.cpp
+++ b/tests/talker_listener_test.cpp
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+
+#include <freertps/freertps.h>
+
+// necessary due to limitations of the API
+static uint32_t n_msg_recv = 0; // cue the raptors plz
+
+void chatter_cb(const void *msg)
+{
+  uint32_t str_len = *((uint32_t *)msg);
+  char buf[128] = {0};
+  for (uint32_t i = 0; i < str_len && i < sizeof(buf)-1; i++)
+    buf[i] = ((uint8_t *)msg)[4+i];
+  printf("I heard: [%s]\n", buf);
+  n_msg_recv++;
+}
+
+TEST(talker_listener_test, talk_n_times)
+{
+  const int n_msg = 15;
+  const double max_seconds = 30;
+  const double target_dt = 0.1;
+
+  fr_time_t t_start = fr_time_now();
+  pid_t pid = fork();
+
+  if (pid == 0)
+  {
+    // child process talks
+
+    printf("HELLO WORLD I WILL TALK AS REQUESTED BECAUSE I AM A ROBOT\r\n");
+    printf("sending %d messages at %.3f-second intervals\n", n_msg, target_dt);
+    freertps_system_init();
+    frudp_pub_t *pub = freertps_create_pub(
+        "chatter", "std_msgs::msg::dds_::String_");
+    frudp_disco_start();
+    char msg[64] = {0};
+    for (uint32_t pub_count = 0;
+         pub_count < n_msg && freertps_system_ok();
+         pub_count++)
+    {
+      frudp_listen(target_dt * 1000000);
+      frudp_disco_tick();
+      snprintf(&msg[4], sizeof(msg) - 4, "Hello World: %d", pub_count);
+      uint32_t rtps_string_len = strlen(&msg[4]) + 1;
+      uint32_t *str_len_ptr = (uint32_t *)msg;
+      *str_len_ptr = rtps_string_len;
+      freertps_publish(pub, (uint8_t *)msg, rtps_string_len + 4);
+      printf("sending: [%s]\r\n", &msg[4]);
+    }
+    frudp_fini();
+    return;
+  }
+
+  freertps_system_init();
+  // parent process listens
+  freertps_create_sub("chatter",
+                      "std_msgs::msg::dds_::String_",
+                      chatter_cb);
+  frudp_disco_start(); // we're alive now; announce ourselves to the world
+  while (freertps_system_ok())
+  {
+    frudp_listen(target_dt * 1000000);
+    frudp_disco_tick(); // stayin' alive FLOOR-TOM FLOOR-TOM CYMBAL-CRASH
+    fr_time_t t = fr_time_now();
+    fr_duration_t dt = fr_time_diff(&t, &t_start);
+    double dt_secs = fr_duration_double(&dt);
+    if (n_msg_recv >= n_msg ||
+        dt_secs > max_seconds)
+      break;
+  }
+  frudp_fini();
+  ASSERT_GE(n_msg_recv, n_msg);
+  printf("HOORAY, I received all the messages.\n");
+}


### PR DESCRIPTION
Connects to #26

I wrote a gtest that forks itself to test both a freertps talker and a listener. :fork_and_knife: I also had to wrap `freertps.h` in an `#ifdef __cplusplus extern "C" { ...` block so that a C++ executable can directly link against freertps.

I only put in the necessary infrastructure to build it with ament, though, since that was slightly faster. I can go back and add a non-ament option for the gtest if desired.

If you compile the gtest, you get similar output to the existing standalone_talker_listener test that's run in a bash script, with the addition of some fancy color-coded output at the end:

```
[       OK ] talker_listener_test.talk_n_times (1503 ms)
[----------] 1 test from talker_listener_test (1503 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1503 ms total)
[  PASSED  ] 1 test.
freertps INFO : discovery fini
freertps INFO : sdp fini
freertps INFO : sedp fini
freertps INFO : udp fini
HOORAY, I received all the messages.
[       OK ] talker_listener_test.talk_n_times (1602 ms)
[----------] 1 test from talker_listener_test (1602 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1602 ms total)
[  PASSED  ] 1 test.
```