### PR TITLE
Remove warning: function declaration isn't a prototype

### DIFF
--- a/include/freertps/disco.h
+++ b/include/freertps/disco.h
@@ -45,11 +45,11 @@
 #define FRUDP_BUILTIN_EP_PARTICIPANT_MESSAGE_DATA_WRITER 0x00000400
 #define FRUDP_BUILTIN_EP_PARTICIPANT_MESSAGE_DATA_READER 0x00000800
 
-void frudp_disco_init();
-void frudp_disco_fini();
+void frudp_disco_init(void);
+void frudp_disco_fini(void);
 
-void frudp_disco_start(); /// must be called to kick off discovery
-void frudp_disco_tick();  /// must be called periodically to broadcast SPDP
+void frudp_disco_start(void); /// must be called to kick off discovery
+void frudp_disco_tick(void);  /// must be called periodically to broadcast SPDP
 
 #define FRUDP_DISCO_TX_BUFLEN 1536
 extern uint8_t g_frudp_disco_tx_buf[FRUDP_DISCO_TX_BUFLEN];

--- a/include/freertps/freertps.h
+++ b/include/freertps/freertps.h
@@ -59,7 +59,7 @@ bool freertps_publish(frudp_pub_t *pub,
 
 extern bool g_freertps_init_complete;
 
-void freertps_start();
+void freertps_start(void);
 
 #ifdef __cplusplus
 }

--- a/include/freertps/part.h
+++ b/include/freertps/part.h
@@ -20,6 +20,6 @@ typedef struct
 } frudp_part_t;
 
 frudp_part_t *frudp_part_find(const frudp_guid_prefix_t *guid_prefix);
-bool frudp_part_create();
+bool frudp_part_create(void);
 
 #endif

--- a/include/freertps/periph/cam.h
+++ b/include/freertps/periph/cam.h
@@ -3,14 +3,14 @@
 
 #include <stdbool.h>
 
-void cam_init();      // image_cb_t cb, image_cb_t dma_cb);
+void cam_init(void);      // image_cb_t cb, image_cb_t dma_cb);
 extern volatile uint8_t *g_cam_frame_buffer;
 
-typedef void (*cam_image_cb_t)();
+typedef void (*cam_image_cb_t)(void);
 void cam_set_image_cb(cam_image_cb_t cb);
 
-void cam_start_image_capture();
-bool cam_image_ready();
+void cam_start_image_capture(void);
+bool cam_image_ready(void);
 
 #if 0
 #define BUFFER_SIZE 0x2850
@@ -32,7 +32,7 @@ typedef struct
 } __attribute__((packed)) camera_config_t;
 
 void camera_init(image_cb_t cb, image_cb_t dma_cb);
-void camera_reset();
+void camera_reset(void);
 
 // generic function, make them weak ?
 void camera_set_framerate(camera_framerate_t framerate);
@@ -40,15 +40,15 @@ void camera_set_color(camera_colorspace_t color_format);
 void camera_set_resolution(camera_resolution_t resolution);
 void camera_set_mode(camera_mode_t mode);
 void camera_set_nightmode(uint8_t mode);
-void camera_take_snapshot();
-void camera_increase_brightness();
-void camera_decrease_brightness();
-void camera_increase_contrast();
-void camera_decrease_contrast();
+void camera_take_snapshot(void);
+void camera_increase_brightness(void);
+void camera_decrease_brightness(void);
+void camera_increase_contrast(void);
+void camera_decrease_contrast(void);
 
 // BSP Functions
-void camera_power_up();  // Idem
-void camera_power_down();  // Idem
+void camera_power_up(void);  // Idem
+void camera_power_down(void);  // Idem
 #endif
 
 

--- a/include/freertps/periph/imu.h
+++ b/include/freertps/periph/imu.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-void imu_init();
+void imu_init(void);
 bool imu_poll_accels(float *xyz);
 
 #endif

--- a/include/freertps/periph/led.h
+++ b/include/freertps/periph/led.h
@@ -4,10 +4,10 @@
 // todo: extend this for multiple LEDs as well, maybe by using plurals, like
 // leds_on(uint32_t mask), etc. etc.
 
-void led_init();
-void led_on();
-void led_off();
-void led_toggle();
+void led_init(void);
+void led_on(void);
+void led_off(void);
+void led_toggle(void);
 
 #endif
 

--- a/include/freertps/psm.h
+++ b/include/freertps/psm.h
@@ -3,8 +3,8 @@
 
 #include "freertps/pub.h"
 
-typedef bool (*rtps_psm_init_func_t)();
-typedef void (*rtps_psm_disco_func_t)();
+typedef bool (*rtps_psm_init_func_t)(void);
+typedef void (*rtps_psm_disco_func_t)(void);
 typedef frudp_pub_t *(*rtps_psm_create_pub_func_t)(
     const char *topic_name, const char *type_name);
 typedef void (*rtps_psm_create_sub_func_t)(

--- a/include/freertps/psm/ser.h
+++ b/include/freertps/psm/ser.h
@@ -1,6 +1,6 @@
 #ifndef RTPS_PSM_SER
 #define RTPS_PSM_SER
 
-void rtps_ser_init();
+void rtps_ser_init(void);
 
 #endif

--- a/include/freertps/sedp.h
+++ b/include/freertps/sedp.h
@@ -5,10 +5,10 @@
 #include "freertps/sub.h"
 #include "freertps/part.h"
 
-void frudp_sedp_init();
-void frudp_sedp_start();
-void frudp_sedp_tick();
-void frudp_sedp_fini();
+void frudp_sedp_init(void);
+void frudp_sedp_start(void);
+void frudp_sedp_tick(void);
+void frudp_sedp_fini(void);
 
 extern frudp_pub_t *g_sedp_sub_pub;
 void sedp_publish_sub(frudp_sub_t *sub);

--- a/include/freertps/spdp.h
+++ b/include/freertps/spdp.h
@@ -4,11 +4,11 @@
 #include "freertps/id.h"
 extern const frudp_eid_t g_spdp_writer_id, g_spdp_reader_id;
 
-void frudp_spdp_init();
-void frudp_spdp_start();
-void frudp_spdp_tick();
-void frudp_spdp_fini();
+void frudp_spdp_init(void);
+void frudp_spdp_start(void);
+void frudp_spdp_tick(void);
+void frudp_spdp_fini(void);
 
-void frudp_spdp_bcast();
+void frudp_spdp_bcast(void);
 
 #endif

--- a/include/freertps/sub.h
+++ b/include/freertps/sub.h
@@ -59,6 +59,6 @@ extern uint32_t g_frudp_num_readers;
 
 void frudp_add_reader(const frudp_reader_t *reader);
 
-void frudp_print_readers();
+void frudp_print_readers(void);
 
 #endif

--- a/include/freertps/system.h
+++ b/include/freertps/system.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-void freertps_system_init();
-bool freertps_system_ok();
+void freertps_system_init(void);
+bool freertps_system_ok(void);
 
 #endif

--- a/include/freertps/time.h
+++ b/include/freertps/time.h
@@ -11,10 +11,10 @@ typedef struct
 
 typedef fr_time_t fr_duration_t;
 
-fr_time_t     fr_time_now();
+fr_time_t     fr_time_now(void);
 fr_duration_t fr_time_diff(const fr_time_t *end, const fr_time_t *start);
 double fr_time_double(const fr_time_t *t);
-double fr_time_now_double(); // convenience function
+double fr_time_now_double(void); // convenience function
 double fr_duration_double(const fr_duration_t *t);
 
 #endif

--- a/include/freertps/timer.h
+++ b/include/freertps/timer.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-typedef void (*freertps_timer_cb_t)();
+typedef void (*freertps_timer_cb_t)(void);
 void freertps_timer_set_freq(uint32_t freq, freertps_timer_cb_t cb);
 
 #endif

--- a/include/freertps/udp.h
+++ b/include/freertps/udp.h
@@ -187,11 +187,11 @@ typedef struct
 // FUNCTIONS
 /////////////////////////////////////////////////////////////////////
 
-bool frudp_init();
-void frudp_fini();
+bool frudp_init(void);
+void frudp_fini(void);
 
-bool frudp_generic_init();
-bool frudp_init_participant_id();
+bool frudp_generic_init(void);
+bool frudp_init_participant_id(void);
 
 bool frudp_add_mcast_rx(const uint32_t group,
                         const uint16_t port); //,
@@ -214,11 +214,11 @@ bool frudp_tx(const uint32_t dst_addr,
               const uint8_t *tx_data,
               const uint16_t tx_len);
 
-uint16_t frudp_ucast_builtin_port();
-uint16_t frudp_mcast_builtin_port();
-uint16_t frudp_ucast_user_port();
-uint16_t frudp_mcast_user_port();
-uint16_t frudp_spdp_port();
+uint16_t frudp_ucast_builtin_port(void);
+uint16_t frudp_mcast_builtin_port(void);
+uint16_t frudp_ucast_user_port(void);
+uint16_t frudp_mcast_user_port(void);
+uint16_t frudp_spdp_port(void);
 
 const char *frudp_ip4_ntoa(const uint32_t addr);
 

--- a/sedp.c
+++ b/sedp.c
@@ -26,7 +26,7 @@ static void frudp_sedp_rx_pubsub_data(frudp_receiver_state_t *rcvr,
                                       const uint16_t scheme,
                                       const uint8_t *data,
                                       const bool is_pub);
-static void frudp_sedp_bcast();
+static void frudp_sedp_bcast(void);
 ////////////////////////////////////////////////////////////////////////////
 // static globals
 static fr_time_t frudp_sedp_last_bcast;


### PR DESCRIPTION
Hi Morgan,
This patch just remove the warning when compiling FreeRTPS on NuttX.